### PR TITLE
fix: Middlware not passing changed props to next middleware

### DIFF
--- a/src/ComponentRegistrar.tsx
+++ b/src/ComponentRegistrar.tsx
@@ -46,10 +46,9 @@ export class ComponentRegistrar<
     private registeredComponents: {
         [key: string]: ComponentRegistration<any, any, TLoadDataServices>
     } = {}
-    private _componentMiddlewares: ComponentRendererMiddleware<
-        TLoadDataServices,
-        TMiddlewareProps
-    >[] = []
+    private _componentMiddlewares: Array<
+        ComponentRendererMiddleware<TLoadDataServices, TMiddlewareProps>
+    > = []
 
     public get componentMiddleware(): ComponentRendererMiddleware<
         TLoadDataServices,
@@ -59,12 +58,12 @@ export class ComponentRegistrar<
             props: ComponentProps,
             middlewareProps: TMiddlewareProps,
             services: RenderFunctionServices<TLoadDataServices>,
-            ...steps: ComponentRendererMiddleware<TLoadDataServices, TMiddlewareProps>[]
+            ...steps: Array<ComponentRendererMiddleware<TLoadDataServices, TMiddlewareProps>>
         ): React.ReactElement<any> | false | null => {
             const [step, ...next] = steps
             return step
-                ? step(props, middlewareProps, services, () =>
-                      pipeline(props, middlewareProps, services, ...next),
+                ? step(props, middlewareProps, services, (stepProps, stepMiddlewareProps) =>
+                      pipeline(stepProps, stepMiddlewareProps, services, ...next),
                   )
                 : null
         }
@@ -138,10 +137,6 @@ export class ComponentRegistrar<
         return this as any
     }
 }
-
-// const Renderer = new ComponentRegistrar().createRenderer()
-
-// <Renderer components={[]}
 
 /** The render function for components, converts the route props into a react component */
 export type MiddlwareHandler<TProps, TMiddlewareProps extends object, LoadDataServices> = (

--- a/src/__tests__/middleware-support.test.tsx
+++ b/src/__tests__/middleware-support.test.tsx
@@ -52,6 +52,7 @@ it('can hook multiple component middleware', () => {
     let middlewareCalled: any
     let middleware2Called: any
     let middleware2Props: any
+    let middleware2ComponentProps: any
     let middleware2Next: any
     const ComponentsRenderer = new LayoutRegistration()
         .registerComponents(registrar =>
@@ -63,16 +64,19 @@ it('can hook multiple component middleware', () => {
                         throw new Error('middlewares called out of order')
                     }
 
-                    return next(props, _, services)
+                    return next({ ...props, additional: true }, _, services)
                 })
 
-                .registerMiddleware((_, middlewareProps: { skipRender2?: boolean }, __, next) => {
-                    middleware2Called = true
-                    middleware2Props = middlewareProps
-                    middleware2Next = next
+                .registerMiddleware(
+                    (componentProps, middlewareProps: { skipRender2?: boolean }, __, next) => {
+                        middleware2Called = true
+                        middleware2ComponentProps = componentProps
+                        middleware2Props = middlewareProps
+                        middleware2Next = next
 
-                    return null
-                }),
+                        return null
+                    },
+                ),
         )
         .createComponentsRenderer()
 
@@ -88,6 +92,7 @@ it('can hook multiple component middleware', () => {
     expect(middlewareCalled).toBe(true)
     expect(middleware2Called).toBe(true)
     expect(middleware2Props).toMatchObject({ skipRender2: true })
+    expect(middleware2ComponentProps).toMatchObject({ additional: true })
 
     // Verify next() will actually render the component
     const renderOutput = mount(middleware2Next())


### PR DESCRIPTION
For example next({ ...props, additional: true }) the next middleware/render would not see additional