### PR TITLE
fix: When middleware calls last next() in chain with props, passed pr…

### DIFF
--- a/src/ComponentRenderer.tsx
+++ b/src/ComponentRenderer.tsx
@@ -35,8 +35,11 @@ export const ComponentRenderer: React.FC<Props<any>> = props => {
         layout: props.layoutApi,
     }
 
-    function render() {
-        const rendered = component.render(props.componentProps, componentServices) || null
+    // A middleware may call next with props, we should use them
+    function render(middlewareComponentProps?: ComponentProps) {
+        const rendered =
+            component.render(middlewareComponentProps || props.componentProps, componentServices) ||
+            null
 
         return rendered
     }

--- a/src/__tests__/middleware-support.test.tsx
+++ b/src/__tests__/middleware-support.test.tsx
@@ -95,8 +95,14 @@ it('can hook multiple component middleware', () => {
     expect(middleware2ComponentProps).toMatchObject({ additional: true })
 
     // Verify next() will actually render the component
-    const renderOutput = mount(middleware2Next())
+    const renderOutput1 = mount(middleware2Next())
+
+    expect(renderOutput1.find(TestComponentWithProps).length).toBe(1)
+    expect(renderOutput1.text()).toContain('test')
+
+    // Verify next() will actually render the component
+    const renderOutput = mount(middleware2Next({ title: 'Override' }))
 
     expect(renderOutput.find(TestComponentWithProps).length).toBe(1)
-    expect(renderOutput.text()).toContain('test')
+    expect(renderOutput.text()).toContain('Override')
 })


### PR DESCRIPTION
…ops should be used