### PR TITLE
Allows middleware to update services

### DIFF
--- a/src/ComponentRegistrar.tsx
+++ b/src/ComponentRegistrar.tsx
@@ -68,8 +68,12 @@ export class ComponentRegistrar<
         ): React.ReactElement<any> | false | null => {
             const [step, ...next] = steps
             return step
-                ? step(props, middlewareProps, services, (stepProps, stepMiddlewareProps) =>
-                      pipeline(stepProps, stepMiddlewareProps, services, ...next),
+                ? step(
+                      props,
+                      middlewareProps,
+                      services,
+                      (stepProps, stepMiddlewareProps, stepServices) =>
+                          pipeline(stepProps, stepMiddlewareProps, stepServices, ...next),
                   )
                 : null
         }

--- a/src/CompositionRegistrar.tsx
+++ b/src/CompositionRegistrar.tsx
@@ -98,8 +98,12 @@ export class CompositionRegistrar<
         ): React.ReactElement<any> | false | null => {
             const [step, ...next] = steps
             return step
-                ? step(props, middlewareProps, services, (stepProps, stepMiddlewareProps) =>
-                      pipeline(stepProps, stepMiddlewareProps, services, ...next),
+                ? step(
+                      props,
+                      middlewareProps,
+                      services,
+                      (stepProps, stepMiddlewareProps, stepServices) =>
+                          pipeline(stepProps, stepMiddlewareProps, stepServices, ...next),
                   )
                 : null
         }


### PR DESCRIPTION
We are able to modify props and middleware props but services would pass
through without being modified. This ensure that any changes middleware
make to a service will flow through.