### PR TITLE
fix: component renderer uses middleware services

### DIFF
--- a/src/ComponentRenderer.tsx
+++ b/src/ComponentRenderer.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ComponentRegistrar } from './ComponentRegistrar'
 import { LayoutApi } from './LayoutApi'
-import { ComponentRendererMiddleware, MiddlwareServices } from './middlewares'
+import { ComponentRendererMiddleware, MiddlwareServices, MiddlwareHandler } from './middlewares'
 
 export interface ComponentProps {
     componentType: string
@@ -33,13 +33,17 @@ export const ComponentRenderer: React.FC<ComponentRendererProps<any>> = props =>
     }
 
     // A middleware may call next with props, we should use them
-    function render(middlewareComponentProps?: ComponentProps) {
+    const render: MiddlwareHandler<any, any, any> = (
+        middlewareComponentProps: ComponentProps,
+        _,
+        services,
+    ) => {
         // component! because we have checked if it's undefined above
         // We are just in a callback here so TypeScript does not maintain the narrowing
         const rendered =
             component!.render(
                 middlewareComponentProps || props.componentProps,
-                componentServices.services,
+                services.services,
             ) || null
 
         return rendered

--- a/src/__tests__/testComponents.tsx
+++ b/src/__tests__/testComponents.tsx
@@ -43,22 +43,20 @@ export const TestComposition: React.FC<{
     </div>
 )
 
-export const testCompositionRegistration = createRegisterableComposition<'main'>()(
-    'test-composition',
-    contentAreas => <TestComposition main={contentAreas.main} />,
-)
+export const testCompositionRegistration = createRegisterableComposition<
+    'main'
+>()('test-composition', contentAreas => <TestComposition main={contentAreas.main} />)
 
 // Test composition with props
 export interface CompositionProps {
     opts: string
 }
-export const TestCompositionWithProps: React.FC<
-    { main: React.ReactElement<any> } & CompositionProps
-> = props => <div>{props.main}</div>
+export const TestCompositionWithProps: React.FC<{
+    main: React.ReactElement<any>
+} & CompositionProps> = props => <div>{props.main}</div>
 
-export const testCompositionWithPropsRegistration = createRegisterableComposition<'main'>()(
-    'test-composition-with-props',
-    (contentAreas, props: { compositionTitle: string }) => (
-        <TestComposition main={contentAreas.main} {...props} />
-    ),
-)
+export const testCompositionWithPropsRegistration = createRegisterableComposition<
+    'main'
+>()('test-composition-with-props', (contentAreas, props: { compositionTitle: string }) => (
+    <TestComposition main={contentAreas.main} {...props} />
+))


### PR DESCRIPTION
ComponentRenderer now uses middleware services rather than the props
services. This means that if the services is altered by a middleware
then that version of services will be the one used by the compoment