### PR TITLE
Support composition data loading.

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,5 +4,5 @@
     "commit": false,
     "linked": [],
     "access": "public",
-    "baseBranch": "master"
+    "baseBranch": "main"
 }

--- a/.changeset/mighty-beans-trade.md
+++ b/.changeset/mighty-beans-trade.md
@@ -1,0 +1,14 @@
+---
+'json-react-layouts': major
+'json-react-layouts-data-loader': major
+---
+
+## Breaking Changes
+
+### `json-react-layouts`
+
+-   `RendererMiddleware` does not depend on `ComponentProps` anymore and will contain a `{ layoutType: string }` value instead to represent the component/composition type.
+
+### `json-react-layouts-data-loader`
+
+-   `middleware` converted to `getMiddleware(type: 'composition' | 'component')` method to support composition middleware.

--- a/packages/json-react-layouts-data-loader/README.md
+++ b/packages/json-react-layouts-data-loader/README.md
@@ -15,12 +15,25 @@ interface MyServices {
 }
 
 const resources = new DataLoaderResources<MyServices>()
-const { middleware, createRegisterableComponentWithData } = init<MyServices>(resources)
+const {
+    getMiddleware,
+    createRegisterableComponentWithData,
+    createRegisterableCompositionWithData,
+} = init<MyServices>(resources)
 
-const componentRegistrar = new ComponentRegistrar()
-    // Register your components, then register the component data loading middleware
-    .registerMiddleware(middleware)
+const layout = LayoutRegistration()
+    .registerComponents(registrar =>
+        registrar
+            // Register your components, then register the component data loading middleware
+            .registerMiddleware(getMiddleware('component')),
+    )
+    .registerCompositions(registrar =>
+        registrar
+            // Register your compositions, then register the composition data loading middleware
+            .registerMiddleware(getMiddleware('composition')),
+    )
 
+// Data-loading component.
 export const testComponentWithDataRegistration = createRegisterableComponentWithData(
     'test-with-data',
     {
@@ -33,6 +46,28 @@ export const testComponentWithDataRegistration = createRegisterableComponentWith
         }
 
         return <TestComponentWithData data={data.result} />
+    },
+)
+
+// Data-loading composition.
+const testCompositionWithDataRegistration = createRegisterableCompositionWithData<'main'>()(
+    'test-with-data', //                                Composition content areas ^^^^^^
+    {
+        // You provide this function to load the data
+        loadData: props => {},
+    },
+    ({ main }, props, data) => {
+    // ^^^^ Receive content areas here.
+        if (!data.loaded) {
+            return <div>Loading...</div>
+        }
+
+        return (
+            <>
+                <TestComponentWithData data={data.result} />
+                {main}
+            </>
+        )
     },
 )
 ```

--- a/packages/json-react-layouts-data-loader/src/__snapshots__/data-loading.test.tsx.snap
+++ b/packages/json-react-layouts-data-loader/src/__snapshots__/data-loading.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`can load data for component 1`] = `
 Object {
   "componentRenderPath": "[0]test-composition/main/[0]",
-  "componentType": "test-with-data",
   "dataProps": Object {
     "data": Object {
       "dataDefinitionArgs": Object {
@@ -13,6 +12,58 @@ Object {
       "result": 3,
     },
   },
+  "layoutType": "test-with-data",
   "length": 3,
+}
+`;
+
+exports[`can load data for composition 1`] = `
+Object {
+  "dataProps": Object {
+    "data": Object {
+      "dataDefinitionArgs": Object {
+        "dataArg": "Foo",
+      },
+      "loaded": true,
+      "result": 3,
+    },
+  },
+  "layoutType": "test-with-data",
+  "length": 3,
+  "main": <ComponentsRenderer
+    additionalComponentProps={Object {}}
+    componentMiddleware={[Function]}
+    componentRegistrations={
+      Object {
+        "get": [Function],
+        "isRegistered": [Function],
+      }
+    }
+    componentRenderPath="[0]test-with-data/main"
+    components={
+      Array [
+        Object {
+          "props": Object {},
+          "type": "test-component",
+        },
+      ]
+    }
+    layoutApi={
+      Object {
+        "component": [Function],
+        "componentRegistrations": Object {
+          "get": [Function],
+          "isRegistered": [Function],
+        },
+        "composition": [Function],
+        "compositionRegistrations": Object {
+          "get": [Function],
+        },
+        "createRenderers": [Function],
+        "nestedComposition": [Function],
+      }
+    }
+    services={Object {}}
+  />,
 }
 `;

--- a/packages/json-react-layouts-data-loader/src/data-loading.test.tsx
+++ b/packages/json-react-layouts-data-loader/src/data-loading.test.tsx
@@ -11,7 +11,7 @@ configure({ adapter: new Adapter() })
 
 it('can load data for component', async () => {
     const resources = new DataLoaderResources<{}>()
-    const { middleware, createRegisterableComponentWithData } = init<{}>(resources)
+    const { getMiddleware, createRegisterableComponentWithData } = init<{}>(resources)
 
     const testComponentWithDataRegistration = createRegisterableComponentWithData(
         'test-with-data',
@@ -31,7 +31,7 @@ it('can load data for component', async () => {
         .registerComponents(registrar =>
             registrar
                 .registerComponent(testComponentWithDataRegistration)
-                .registerMiddleware(middleware),
+                .registerMiddleware(getMiddleware('component')),
         )
         .registerCompositions(registrar =>
             registrar.registerComposition(testCompositionRegistration),
@@ -67,12 +67,69 @@ it('can load data for component', async () => {
     expect(component.props()).toMatchSnapshot()
 })
 
+it('can load data for composition', async () => {
+    const resources = new DataLoaderResources<{}>()
+    const { getMiddleware, createRegisterableCompositionWithData } = init<{}>(resources)
+
+    const testCompositionWithDataRegistration = createRegisterableCompositionWithData<'main'>()(
+        'test-with-data',
+        lengthCalculatorDataDefinition,
+        ({ main }, props, data) => {
+            return (
+                <TestCompositionWithData
+                    main={main}
+                    length={data.loaded ? data.result : undefined}
+                    {...props}
+                    {...{ dataProps: { data } }}
+                />
+            )
+        },
+    )
+
+    const layout = LayoutRegistration()
+        .registerComponents(registrar => registrar.registerComponent(testComponentRegistration))
+        .registerCompositions(registrar =>
+            registrar
+                .registerComposition(testCompositionWithDataRegistration)
+                .registerMiddleware(getMiddleware('composition')),
+        )
+    const renderers = layout.createRenderers({
+        services: {},
+    })
+
+    const wrapper = mount(
+        <DataProvider resources={resources} globalProps={{}}>
+            {renderers.renderCompositions(
+                layout.composition({
+                    type: 'test-with-data',
+                    contentAreas: {
+                        main: [
+                            layout.component({
+                                type: 'test-component',
+                                props: {},
+                            }),
+                        ],
+                    },
+                    props: { dataDefinitionArgs: { dataArg: 'Foo' } },
+                }),
+            )}
+        </DataProvider>,
+    )
+
+    expect(wrapper.find(TestCompositionWithData).text()).toBe('Loading#TestComponent#')
+    await act(() => new Promise(resolve => setTimeout(resolve)))
+
+    const composition = wrapper.update().find(TestCompositionWithData)
+    expect(composition.text()).toBe('Length: 3#TestComponent#')
+    expect(composition.props()).toMatchSnapshot()
+})
+
 it('cap wrap data load function', async () => {
     let wrapArgs: any
     let wrapServices: any
     let wrapContext: any
     const resources = new DataLoaderResources<{ serviceProp: 'example' }>()
-    const { middleware, createRegisterableComponentWithData } = init<{ serviceProp: 'example' }>(
+    const { getMiddleware, createRegisterableComponentWithData } = init<{ serviceProp: 'example' }>(
         resources,
         load => (args, services, context) => {
             wrapArgs = args
@@ -100,7 +157,7 @@ it('cap wrap data load function', async () => {
         .registerComponents(registrar =>
             registrar
                 .registerComponent(testComponentWithDataRegistration)
-                .registerMiddleware(middleware),
+                .registerMiddleware(getMiddleware('component')),
         )
         .registerCompositions(registrar =>
             registrar.registerComposition(testCompositionRegistration),
@@ -139,7 +196,7 @@ it('cap wrap data load function', async () => {
 
 it('component can provide additional arguments dynamically', async () => {
     const resources = new DataLoaderResources<{}>()
-    const { middleware, createRegisterableComponentWithData } = init<{}>(resources)
+    const { getMiddleware, createRegisterableComponentWithData } = init<{}>(resources)
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     let updateMultiplier: (multiplier: number) => void = () => {}
 
@@ -187,7 +244,7 @@ it('component can provide additional arguments dynamically', async () => {
         .registerComponents(registrar =>
             registrar
                 .registerComponent(testComponentWithDataRegistration)
-                .registerMiddleware(middleware),
+                .registerMiddleware(getMiddleware('component')),
         )
         .registerCompositions(registrar =>
             registrar.registerComposition(testCompositionRegistration),
@@ -244,9 +301,118 @@ it('component can provide additional arguments dynamically', async () => {
     })
 })
 
-const { createRegisterableComposition } = getRegistrationCreators<{}>()
+it('composition can provide additional arguments dynamically', async () => {
+    const resources = new DataLoaderResources<{}>()
+    const { getMiddleware, createRegisterableCompositionWithData } = init<{}>(resources)
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    let updateMultiplier: (multiplier: number) => void = () => {}
 
-// Test component with data
+    const lengthCalculatorWithMultiplierDataDefinition: DataDefinition<
+        { dataArg: string },
+        number,
+        {},
+        { multiplier: number }
+    > = {
+        // Additional params can come from anywhere, for instance redux or
+        // other environmental variables (window.location?)
+        useRuntimeParams: () => {
+            const [multiplier, setMultiplier] = React.useState(2)
+            React.useEffect(() => {
+                updateMultiplier = setMultiplier
+            }, [])
+
+            return {
+                multiplier,
+            }
+        },
+        loadData: props =>
+            new Promise(resolve =>
+                setTimeout(() => {
+                    resolve(props.dataArg.length * props.multiplier)
+                }),
+            ),
+    }
+
+    const testCompositionWithDataRegistration = createRegisterableCompositionWithData<'main'>()(
+        'test-with-data',
+        lengthCalculatorWithMultiplierDataDefinition,
+        ({ main }, props, data) => {
+            return (
+                <TestCompositionWithData
+                    main={main}
+                    length={data.loaded ? data.result : undefined}
+                    {...props}
+                    {...{ dataProps: { data } }}
+                />
+            )
+        },
+    )
+
+    const layout = LayoutRegistration()
+        .registerComponents(registrar => registrar.registerComponent(testComponentRegistration))
+        .registerCompositions(registrar =>
+            registrar
+                .registerComposition(testCompositionWithDataRegistration)
+                .registerMiddleware(getMiddleware('composition')),
+        )
+
+    const renderers = layout.createRenderers({
+        services: {},
+    })
+
+    const wrapper = mount(
+        <DataProvider resources={resources} globalProps={{}}>
+            {renderers.renderCompositions(
+                layout.composition({
+                    type: 'test-with-data',
+                    contentAreas: {
+                        main: [
+                            layout.component({
+                                type: 'test-component',
+                                props: {},
+                            }),
+                        ],
+                    },
+                    props: {
+                        dataDefinitionArgs: {
+                            dataArg: 'Foo',
+                        },
+                    },
+                }),
+            )}
+        </DataProvider>,
+    )
+
+    await act(() => new Promise(resolve => setTimeout(resolve)))
+
+    let composition = wrapper.update().find(TestCompositionWithData)
+    expect(composition.text()).toBe('Length: 6#TestComponent#')
+    expect(composition.props()).toMatchObject({
+        dataProps: {
+            data: {
+                dataDefinitionArgs: { dataArg: 'Foo', multiplier: 2 },
+            },
+        },
+    })
+
+    act(() => {
+        updateMultiplier(3)
+    })
+    await act(() => new Promise(resolve => setTimeout(resolve)))
+
+    composition = wrapper.update().find(TestCompositionWithData)
+    expect(composition.text()).toBe('Length: 9#TestComponent#')
+    expect(composition.props()).toMatchObject({
+        dataProps: {
+            data: {
+                dataDefinitionArgs: { dataArg: 'Foo', multiplier: 3 },
+            },
+        },
+    })
+})
+
+const TestComponent: React.FC = () => <div>#TestComponent#</div>
+
 const TestComponentWithData: React.FC<{ length: number | undefined }> = ({ length }) => (
     <div>{length ? `Length: ${length}` : 'Loading'}</div>
 )
@@ -255,10 +421,25 @@ const TestComposition: React.FC<{ main: React.ReactElement<any> }> = props => (
     <div>{props.main}</div>
 )
 
+const TestCompositionWithData: React.FC<{
+    main: React.ReactElement<any>
+    length: number | undefined
+}> = ({ length, main }) => (
+    <div>
+        <div>{length ? `Length: ${length}` : 'Loading'}</div>
+        {main}
+    </div>
+)
+
+const { createRegisterableComposition, createRegisterableComponent } = getRegistrationCreators<{}>()
 const testCompositionRegistration = createRegisterableComposition<'main'>()(
     'test-composition',
     contentAreas => <TestComposition main={contentAreas.main} />,
 )
+
+const testComponentRegistration = createRegisterableComponent('test-component', () => (
+    <TestComponent />
+))
 
 const lengthCalculatorDataDefinition: DataDefinition<{ dataArg: string }, number, {}, {}> = {
     loadData: props =>

--- a/packages/json-react-layouts-data-loader/src/get-data-args.ts
+++ b/packages/json-react-layouts-data-loader/src/get-data-args.ts
@@ -2,20 +2,41 @@ import { DataDefinition } from './DataLoading'
 import { ComponentRegistration } from '../../json-react-layouts/src/ComponentRegistrar'
 import { CompositionRegistration } from '../../json-react-layouts/src/CompositionRegistrar'
 
-type PotentialDataDefinition<Services extends {}> = (
-    | ComponentRegistration<any, any, any>
-    | CompositionRegistration<any, any, any, any>
+export type RegistrationWithDataDefinition<
+    Type extends string,
+    ContentAreas extends string,
+    Props extends {},
+    Services extends {},
+    DataLoadArguments extends {},
+    TData,
+    AdditionalParams extends {} = {}
+> = (
+    | ComponentRegistration<Type, Props, Services>
+    | CompositionRegistration<Type, ContentAreas, Services, Props>
 ) & {
-    dataDefinition?: DataDefinition<any, any, Services, any>
+    dataDefinition?: DataDefinition<DataLoadArguments, TData, Services, AdditionalParams>
 }
 
-export function getDataArgs<Services extends {}>(
+export function getDataArgs<
+    Type extends string,
+    ContentAreas extends string,
+    Props extends {},
+    Services extends {},
+    DataLoadArguments extends {},
+    TData,
+    AdditionalParams extends {} = {}
+>(
     registration:
-        | ComponentRegistration<any, any, any>
-        | CompositionRegistration<any, any, any, any>,
+        | RegistrationWithDataDefinition<
+              Type,
+              ContentAreas,
+              Props,
+              Services,
+              DataLoadArguments,
+              TData,
+              AdditionalParams
+          >
+        | undefined,
 ): DataDefinition<any, any, Services, any> | undefined {
-    // Registration may or may not have a dataDefinition.
-    // Assertion to undefined | DataDefinition should be safe.
-    const dataDefinition = (registration as PotentialDataDefinition<Services>)?.dataDefinition
-    return dataDefinition
+    return registration?.dataDefinition
 }

--- a/packages/json-react-layouts-data-loader/src/get-data-args.ts
+++ b/packages/json-react-layouts-data-loader/src/get-data-args.ts
@@ -1,17 +1,21 @@
-import { LayoutApi } from 'json-react-layouts'
 import { DataDefinition } from './DataLoading'
+import { ComponentRegistration } from '../../json-react-layouts/src/ComponentRegistrar'
+import { CompositionRegistration } from '../../json-react-layouts/src/CompositionRegistrar'
 
-export function getComponentDataArgs<Services extends {}>(
-    layout: LayoutApi<any, any, any, any, Services>,
-    componentType: string,
+type PotentialDataDefinition<Services extends {}> = (
+    | ComponentRegistration<any, any, any>
+    | CompositionRegistration<any, any, any, any>
+) & {
+    dataDefinition?: DataDefinition<any, any, Services, any>
+}
+
+export function getDataArgs<Services extends {}>(
+    registration:
+        | ComponentRegistration<any, any, any>
+        | CompositionRegistration<any, any, any, any>,
 ): DataDefinition<any, any, Services, any> | undefined {
-    const componentDataDefinition = layout.componentRegistrations.get(componentType)
-
-    // This can be undefined
-    if (!componentDataDefinition) {
-        return
-    }
-    const dataDefinition = (componentDataDefinition as any).dataDefinition
-
+    // Registration may or may not have a dataDefinition.
+    // Assertion to undefined | DataDefinition should be safe.
+    const dataDefinition = (registration as PotentialDataDefinition<Services>)?.dataDefinition
     return dataDefinition
 }

--- a/packages/json-react-layouts-data-loader/src/index.tsx
+++ b/packages/json-react-layouts-data-loader/src/index.tsx
@@ -5,11 +5,13 @@ import {
     RenderFunction,
     MiddlwareHandler,
     MiddlwareServices,
+    CompositionRegistration,
+    CompositionRenderFunction,
 } from 'json-react-layouts'
 import { DataLoaderResources } from 'react-ssr-data-loader'
 
 import { ComponentState, LoadArguments, DataDefinition, MaybeLoaded, LoadData } from './DataLoading'
-import { getComponentDataArgs } from './get-data-args'
+import { getDataArgs } from './get-data-args'
 
 type RenderComponentWithDataProps<
     ComponentProps extends {},
@@ -17,6 +19,21 @@ type RenderComponentWithDataProps<
     TConfig extends {},
     Services
 > = (
+    props: ComponentProps,
+    dataProps: MaybeLoaded<TData> & {
+        dataDefinitionArgs: TConfig
+    },
+    services: Services,
+) => React.ReactElement<any> | false | null
+
+type RenderCompositionWithDataProps<
+    TContentAreas extends string,
+    ComponentProps extends {},
+    TData,
+    TConfig extends {},
+    Services
+> = (
+    contentAreas: { [key in TContentAreas]: React.ReactElement<any> },
     props: ComponentProps,
     dataProps: MaybeLoaded<TData> & {
         dataDefinitionArgs: TConfig
@@ -45,7 +62,29 @@ export function init<Services extends object>(
         ComponentProps & { dataDefinitionArgs: DataLoadArgs },
         Services
     >
-    middleware: RendererMiddleware<Services, {}>
+    createRegisterableCompositionWithData: <ContentAreas extends string>() => <
+        CompositionType extends string,
+        CompositionProps extends object,
+        DataLoadArgs extends object,
+        CompositionData,
+        AdditionalParams extends object
+    >(
+        type: CompositionType,
+        dataDefinition: DataDefinition<DataLoadArgs, CompositionData, Services, AdditionalParams>,
+        render: RenderCompositionWithDataProps<
+            ContentAreas,
+            CompositionProps,
+            CompositionData,
+            DataLoadArgs,
+            Services
+        >,
+    ) => CompositionRegistration<
+        CompositionType,
+        ContentAreas,
+        Services,
+        CompositionProps & { dataDefinitionArgs: DataLoadArgs }
+    >
+    getMiddleware: (type: 'component' | 'composition') => RendererMiddleware<Services, {}>
 } {
     const useComponentData = resources.registerResource<any, LoadArguments<Services>>(
         'component-data-loader',
@@ -119,18 +158,18 @@ export function init<Services extends object>(
 
     function WithDataLoad({
         dataDefinition,
-        componentProps,
+        props,
         services,
         next,
         middlewareProps,
     }: {
         dataDefinition: DataDefinition<any, any, Services, any>
-        componentProps: any
+        props: any
         services: MiddlwareServices<Services>
         next: MiddlwareHandler<any, {}, Services>
         middlewareProps: {}
     }) {
-        const dataDefinitionArgs = componentProps.dataDefinitionArgs
+        const dataDefinitionArgs = props.dataDefinitionArgs
 
         const renderProps = useComponentData({
             dataDefinition,
@@ -150,7 +189,7 @@ export function init<Services extends object>(
         return (
             next(
                 {
-                    ...componentProps,
+                    ...props,
                     ...data,
                 },
                 middlewareProps,
@@ -206,39 +245,101 @@ export function init<Services extends object>(
             // { type: TType, props: TProps & { dataDefinition: TData } }
             return registrationWithData
         },
-        middleware: (componentProps, middlewareProps, services, next) => {
-            const dataDefinition = getComponentDataArgs<Services>(
-                services.layout,
-                componentProps.componentType,
-            )
+        createRegisterableCompositionWithData: <TContentAreas extends string>() => <
+            CompositionType extends string,
+            CompositionProps extends {},
+            DataLoadArgs extends {},
+            CompositionData,
+            AdditionalParams extends object
+        >(
+            type: CompositionType,
+            dataDefinition: DataDefinition<
+                DataLoadArgs,
+                CompositionData,
+                Services,
+                AdditionalParams
+            >,
+            render: RenderCompositionWithDataProps<
+                TContentAreas,
+                CompositionProps,
+                CompositionData,
+                DataLoadArgs,
+                Services
+            >,
+        ) => {
+            // This is quite a complex transform which can't be modelled in typescript.
+            //
+            // The dataDefinition which is passed to this object is hidden from the types returned
+            // The content area renderer has a data loader which will look for this property
+            // Then use the loadData function
+            const normalRender: CompositionRenderFunction<
+                TContentAreas,
+                CompositionProps &
+                    ComponentState<CompositionData> & {
+                        dataDefinitionArgs: DataLoadArgs & AdditionalParams
+                    },
+                Services
+            > = (contentAreas, { data, dataDefinitionArgs, ...rest }, services) => {
+                return render(
+                    contentAreas,
+                    rest as any,
+                    {
+                        ...data,
+                        dataDefinitionArgs,
+                    },
+                    services,
+                )
+            }
 
-            if (dataDefinition) {
-                if (dataDefinition.useRuntimeParams) {
-                    return (
-                        <DataLoaderWithRuntimeParams
-                            dataDefinition={dataDefinition}
-                            componentProps={componentProps}
-                            services={services}
-                            next={next}
-                            middlewareProps={middlewareProps}
-                        />
-                    )
-                }
+            const registrationWithData: any = { type, render: normalRender, dataDefinition }
+            // Once the data is loaded it will be passed to the render function on the
+            // data prop, which will be typed as LoadedData<TData>
 
+            // The route info looks like this:
+            // { type: TType, props: TProps & { dataDefinition: TData } }
+            return registrationWithData
+        },
+        getMiddleware: type => (props, middlewareProps, services, next) => {
+            const registration =
+                type === 'component'
+                    ? services.layout.componentRegistrations.get(props.layoutType)
+                    : services.layout.compositionRegistrations.get(props.layoutType)
+
+            // No registration found for this component.
+            if (!registration) {
+                return next(props, middlewareProps, services)
+            }
+
+            const dataDefinition = getDataArgs<Services>(registration)
+
+            // dataDefinition does not exist on all components.
+            if (!dataDefinition) {
+                return next(props, middlewareProps, services)
+            }
+
+            if (dataDefinition.useRuntimeParams) {
+                return (
+                    <DataLoaderWithRuntimeParams
+                        dataDefinition={dataDefinition}
+                        componentProps={props}
+                        services={services}
+                        next={next}
+                        middlewareProps={middlewareProps}
+                    />
+                )
+            } else {
                 return (
                     <WithDataLoad
                         dataDefinition={dataDefinition}
-                        componentProps={componentProps}
+                        props={props}
                         services={services}
                         next={next}
                         middlewareProps={middlewareProps}
                     />
                 )
             }
-
-            return next(componentProps, middlewareProps, services)
         },
     }
 }
 
-export { DataDefinition, MaybeLoaded, getComponentDataArgs }
+export { DataDefinition, MaybeLoaded, getDataArgs as getComponentDataArgs }

--- a/packages/json-react-layouts-data-loader/src/index.tsx
+++ b/packages/json-react-layouts-data-loader/src/index.tsx
@@ -310,7 +310,7 @@ export function init<Services extends object>(
                 return next(props, middlewareProps, services)
             }
 
-            const dataDefinition = getDataArgs<Services>(registration)
+            const dataDefinition = getDataArgs(registration)
 
             // dataDefinition does not exist on all components.
             if (!dataDefinition) {

--- a/packages/json-react-layouts/README.md
+++ b/packages/json-react-layouts/README.md
@@ -215,6 +215,8 @@ LayoutRegistration().registerComponents(registrar =>
 )
 ```
 
+Middlewares can also be applied to compositions.
+
 ## Debug Logging
 
 JSON React Layouts has debug logging available if you want it. We use the NPM package [debug](https://www.npmjs.com/package/debug) for this.

--- a/packages/json-react-layouts/src/LayoutRegistration.tsx
+++ b/packages/json-react-layouts/src/LayoutRegistration.tsx
@@ -31,9 +31,9 @@ interface RegisterComponentsStep<Services extends {}> {
 export interface CompositionRegistrationBuilderStart<
     Components extends ComponentInformation<any, any>,
     ComponentMiddlewaresProps extends {},
-    Services
+    Services extends {} = {}
 > {
-    registerComposition<TType extends string, TContentAreas extends string, TProps>(
+    registerComposition<TType extends string, TContentAreas extends string, TProps extends {} = {}>(
         registration: CompositionRegistration<TType, TContentAreas, Services, TProps>,
     ): CompositionRegistrationBuilder<
         Components,
@@ -49,9 +49,9 @@ export interface CompositionRegistrationBuilder<
     ComponentMiddlewaresProps extends {},
     Compositions extends CompositionInformation<any, any, any>,
     CompositionMiddlewaresProps extends {},
-    Services
+    Services extends {} = {}
 > {
-    registerComposition<TType extends string, TContentAreas extends string, TProps>(
+    registerComposition<TType extends string, TContentAreas extends string, TProps extends {} = {}>(
         registration: CompositionRegistration<TType, TContentAreas, Services, TProps>,
     ): CompositionRegistrationBuilder<
         Components,

--- a/packages/json-react-layouts/src/middlewares.ts
+++ b/packages/json-react-layouts/src/middlewares.ts
@@ -1,6 +1,5 @@
 import { LayoutApi } from './LayoutApi'
 import { jrlDebug } from './log'
-import { ComponentProps } from './renderers/component-renderer'
 
 export interface MiddlwareServices<Services extends {}> {
     layout: LayoutApi<any, any, any, any, Services>
@@ -16,18 +15,23 @@ export type MiddlwareHandler<TProps, TMiddlewareProps extends {}, LoadDataServic
     services: MiddlwareServices<LoadDataServices>,
 ) => React.ReactElement<any> | false | null
 
+interface ComponentOrCompositionProps {
+    layoutType: string
+    [props: string]: any
+}
+
 export type RendererMiddleware<Services extends {}, MiddlewareProps extends {}> = (
-    props: ComponentProps,
+    props: ComponentOrCompositionProps,
     middlewareProps: MiddlewareProps,
     services: MiddlwareServices<Services>,
-    next: MiddlwareHandler<ComponentProps, MiddlewareProps, Services>,
+    next: MiddlwareHandler<ComponentOrCompositionProps, MiddlewareProps, Services>,
 ) => React.ReactElement<any> | false | null
 
 export function composeMiddleware<Services extends {}, MiddlewareProps extends {}>(
     componentMiddlewares: Array<RendererMiddleware<Services, MiddlewareProps>>,
 ): RendererMiddleware<Services, MiddlewareProps> {
     const pipeline = (
-        props: ComponentProps,
+        props: ComponentOrCompositionProps,
         middlewareProps: MiddlewareProps,
         services: MiddlwareServices<Services>,
         ...steps: Array<RendererMiddleware<Services, MiddlewareProps>>

--- a/packages/json-react-layouts/src/renderers/component-renderer.tsx
+++ b/packages/json-react-layouts/src/renderers/component-renderer.tsx
@@ -54,8 +54,15 @@ export const ComponentRenderer: React.FC<ComponentRendererProps> = ({
         return rendered
     }
 
+    const { componentType, ...rest } = componentProps
+
     const middlewareRender =
-        componentMiddleware(componentProps, middlewareProps, componentServices, render) || null
+        componentMiddleware(
+            { layoutType: componentType, ...rest },
+            middlewareProps,
+            componentServices,
+            render,
+        ) || null
 
     return middlewareRender
 }

--- a/packages/json-react-layouts/src/renderers/composition-renderer.tsx
+++ b/packages/json-react-layouts/src/renderers/composition-renderer.tsx
@@ -36,8 +36,8 @@ export const CompositionRenderer: React.FunctionComponent<CompositionRendererPro
      * key as this logic is duped outside of react for the ssr
      */
     compositionDebug('Rendering: %o', {
-        componentRenderPath: componentRenderPath,
         type: composition.type,
+        componentRenderPath: componentRenderPath,
     })
 
     const { contentAreas, props: compositionProps, ...middlewareProps } = composition
@@ -95,7 +95,15 @@ export const CompositionRenderer: React.FunctionComponent<CompositionRendererPro
     }
 
     const middlewareRender =
-        compositionMiddleware(composition.props, middlewareProps, componentServices, render) || null
+        compositionMiddleware(
+            {
+                layoutType: composition.type,
+                ...composition.props,
+            },
+            middlewareProps,
+            componentServices,
+            render,
+        ) || null
 
     return middlewareRender
 }


### PR DESCRIPTION
## What

- Fix an issue where compositions were not passing their compositionType into middleware.
- Support data loading in compositions
  - Accomplished via new `createRegisterableCompositionWithData()` builder.
  - `middleware` converted into function that returns an appropriate middleware for components or compositions. (This is to prevent the edge-case where a component and composition are defined with the same type)

## Breaking Changes

### `json-react-layouts`
- `RendererMiddleware` does not depend on `ComponentProps` anymore and will contain a `{ layoutType: string }` value instead to represent the component/composition type.

### `json-react-layouts-data-loader`
- `middleware` converted to `getMiddleware(type: 'composition' | 'component')` method to support composition middleware.